### PR TITLE
Allow Laravel 6.x and 7.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "laravel/framework": "^5.2",
+        "laravel/framework": "^5.2 || ^6.0 || ^7.0",
         "parse/php-sdk": "^1.2.0"
     },
     "autoload": {
@@ -19,5 +19,8 @@
                 "Parziphal\\Parse\\ParseServiceProvider"
             ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.1"
     }
 }


### PR DESCRIPTION
Please, help with Issue #30 

No additional constraints, no breaking changes. This 100% safe change will allow more people to use your package directly (not making forks just because of this problem).